### PR TITLE
Handle null values in keyArrangeDeep

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ export function keyArrangeDeep(obj, callback) {
 	if (Array.isArray(obj)) {
 		return obj.map(v => keyArrangeDeep(v, callback));
 	} else if (typeof obj == 'object') {
+		if (obj == null) {
+			return null;
+		}
 		return Object.fromEntries(
 			Object.entries(
 				keyArrange(obj, callback)

--- a/test/keyArrangeDeep.js
+++ b/test/keyArrangeDeep.js
@@ -102,6 +102,7 @@ describe('keyArrangeDeep - mixed types', function() {
 			1337,
 		],
 		alpha: 123,
+		zeta: null,
 		si: {
 			theta: 999,
 			eta: 'value!',
@@ -122,8 +123,8 @@ describe('keyArrangeDeep - mixed types', function() {
 		expect(outObj).to.have.property('gamma');
 		expect(outObj).to.have.property('si');
 
-		expect(_.keys(outObj)).to.have.length(4);
-		expect(_.keys(outObj)).to.deep.equal(['alpha', 'beta', 'gamma', 'si']);
+		expect(_.keys(outObj)).to.have.length(5);
+		expect(_.keys(outObj)).to.deep.equal(['alpha', 'beta', 'gamma', 'si', 'zeta']);
 
 		expect(outObj.gamma).to.be.an('array');
 		expect(outObj.gamma).to.have.length(3);
@@ -145,5 +146,7 @@ describe('keyArrangeDeep - mixed types', function() {
 		expect(outObj.si).to.have.property('eta', 'value!');
 		expect(outObj.si).to.have.property('theta', 999);
 		expect(_.keys(outObj.si)).to.deep.equal(['eta', 'theta']);
+
+		expect(outObj.zeta).to.equal(null)
 	});
 });


### PR DESCRIPTION
## Problem

We hit a problem where keyArrangeDeep dies with `Uncaught TypeError: Cannot convert undefined or null to object` when any key has a null value assigned. 

## Solution

I added an early return check for null values and updated the tests.